### PR TITLE
Traducción de la sección *Installation*

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -37,7 +37,7 @@ También se encuentra disponible en [jsdelivr](//cdn.jsdelivr.net/vue/{{vue_vers
 
 ## NPM
 
-NPM es el método de instalación recomendado cuando se construyen aplicaciones de gran escala con Vue. Se complementa de buena manera con empaquetadores de módulos como [Webpack](http://webpack.github.io/) o [Browserify](http://browserify.org/). Vue también provee herramientas complementarias para la creación de [Componentes de un solo archivo](single-file-components.html).
+NPM es el método de instalación recomendado cuando se construyen aplicaciones de gran escala con Vue. Se integra bien con empaquetadores de módulos como [Webpack](http://webpack.github.io/) o [Browserify](http://browserify.org/). Vue también provee herramientas complementarias para la creación de [Componentes de un solo archivo](single-file-components.html).
 
 ``` bash
 # última versión estable
@@ -47,11 +47,11 @@ $ npm install vue
 
 Hay dos versiones disponibles, la independiente y la _runtime-only_. La diferencia es que la primera incluye un **compilador de plantillas** y la última no.
 
-El compilador de plantillas es responsable de compilar plantillas de Vue en funciones de renderizado de Javascript puro. Si desea usar la opción `template`, entonces necesita el compilador.
+El compilador de plantillas es responsable de compilar plantillas de Vue en funciones de renderizado de JavaScript puro. Si desea usar la opción `template`, entonces necesita el compilador.
 
 - La versión independiente incluye el compilador y soporta la opción `template`. **También depende de la presencia de APIs del navegador, por lo que no puede usarlo para renderizado del lado servidor.**
 
-- La versión _runtime-only_ no incluye el compilador de plantillas y no soporta la opción `template`. solo puede usar la opción `render` cuando se está usando esta versión, pero funciona con componentes de un solo archivo, porque las plantillas de los componentes de un solo archivo son pre-compiladas en funciones `render` durante la etapa de construcción. La versión _runtime-only_ es aproximadamente 30% más liviana que la versión independiente, ocupando solo {{ro_gz_size}}kb min+gzip.
+- La versión _runtime-only_ no incluye el compilador de plantillas y no soporta la opción `template`. Solo puede usar la opción `render` cuando se está usando esta versión, pero funciona con componentes de un solo archivo, porque las plantillas de los componentes de un solo archivo son pre-compiladas en funciones `render` durante la etapa de construcción. La versión _runtime-only_ es aproximadamente 30% más liviana que la versión independiente, ocupando solo {{ro_gz_size}}kb min+gzip.
 
 Por defecto, el paquete NPM exporta la versión **runtime-only**. Para usar la versión independiente, añada el siguiente alias en su archivo de configuración de Webpack:
 
@@ -81,7 +81,7 @@ Por otro lado, la versión _runtime-only_ es completamente compatible con CSP. C
 
 ## CLI
 
-Vue.js provee una [CLI oficial](https://github.com/vuejs/vue-cli) para estructurar rápidamente aplicaciones ambiciosas de una sola página. Provee configuraciones _todo-en-uno_ para un flujo de trabajo frontend moderno. Solo toma unos minutos estar preparado para el desarrollo con: recarga en caliente, _lint-on-save_ y versiones listas para producción:
+Vue.js provee una [CLI oficial](https://github.com/vuejs/vue-cli) para estructurar rápidamente Aplicaciones de una Sola Página (SPA por sus siglas en inglés). Provee configuraciones _todo-en-uno_ para un flujo de trabajo frontend moderno. Solo toma unos minutos estar preparado para el desarrollo con: recarga en caliente, _lint-on-save_ y versiones listas para producción:
 
 ``` bash
 # Instale vue-cli

--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -9,52 +9,51 @@ gz_size: "24.72"
 ro_gz_size: "17.14"
 ---
 
-### Compatibility Note
+### Nota de compatibilidad
 
-Vue does **not** support IE8 and below, because it uses ECMAScript 5 features that are un-shimmable in IE8. However it supports all [ECMAScript 5 compliant browsers](http://caniuse.com/#feat=es5).
+Vue **no** está soportado en IE8 ni versiones anteriores, porque usa características de ECMAScript 5 que son irreproducibles en ellos. Sin embargo soporta todos los [navegadores compatibles con ECMAScript 5](http://caniuse.com/#feat=es5).
 
-### Release Notes
+### Notas de lanzamiento
 
-Detailed release notes for each version are available on [GitHub](https://github.com/vuejs/vue/releases).
+Se pueden encontrar notas de lanzamiento detalladas para cada versión en [GitHub](https://github.com/vuejs/vue/releases).
 
-## Standalone
+## Versión independiente
 
-Simply download and include with a script tag. `Vue` will be registered as a global variable.
+Simplemente descarguela e incluyala con una etiqueta script. `Vue` se registrará como una variable global.
 
-<p class="tip">Don't use the minified version during development. You will miss out all the nice warnings for common mistakes!</p>
+<p class="tip">No use la versión minificada durante el desarrollo. ¡Perderá todas las advertencias para los errores comunes!</p>
 
 <div id="downloads">
-<a class="button" href="/js/vue.js" download>Development Version</a><span class="light info">With full warnings and debug mode</span>
+<a class="button" href="/js/vue.js" download>Versión de desarrollo</a><span class="light info">Con todas las advertencias y el modo depuración.</span>
 
-<a class="button" href="/js/vue.min.js" download>Production Version</a><span class="light info">Warnings stripped, {{gz_size}}kb min+gzip</span>
+<a class="button" href="/js/vue.min.js" download>Versión de producción</a><span class="light info">Advertencias eliminadas, {{gz_size}}kb min+gzip</span>
 </div>
 
 ### CDN
 
-Recommended: [unpkg](https://unpkg.com/vue/dist/vue.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [unpkg.com/vue/](https://unpkg.com/vue/).
+Recomendación: [unpkg](https://unpkg.com/vue/dist/vue.js), el cual contendrá la última versión apenas haya sido publicada en npm. También puede explorar el código fuente del paquete npm en [unpkg.com/vue/](https://unpkg.com/vue/).
 
-Also available on [jsdelivr](//cdn.jsdelivr.net/vue/{{vue_version}}/vue.js) or [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js), but these two services take some time to sync so the latest release may not be available yet.
+También se encuentra disponible en [jsdelivr](//cdn.jsdelivr.net/vue/{{vue_version}}/vue.js) o [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js), pero estos dos servicios pueden tardar algo de tiempo en sincronizar, por lo que la última versión puede no estar disponible todavía.
 
 ## NPM
 
-NPM is the recommended installation method when building large scale applications with Vue. It pairs nicely with module bundlers such as [Webpack](http://webpack.github.io/) or [Browserify](http://browserify.org/). Vue also provides accompanying tools for authoring [Single File Components](single-file-components.html).
+NPM es el método de instalación recomendado cuando se construyen aplicaciones de gran escala con Vue. Se complementa de buena manera con empaquetadores de módulos como [Webpack](http://webpack.github.io/) o [Browserify](http://browserify.org/). Vue también provee herramientas complementarias para la creación de [Componentes de un solo archivo](single-file-components.html).
 
 ``` bash
-# latest stable
+# última versión estable
 $ npm install vue
 ```
+### Versión independiente vs. versión _Runtime-only_
 
-### Standalone vs. Runtime-only Build
+Hay dos versiones disponibles, la independiente y la _runtime-only_. La diferencia es que la primera incluye un **compilador de plantillas** y la última no.
 
-There are two builds available, the standalone build and the runtime-only build. The difference being that the former includes the **template compiler** and the latter does not.
+El compilador de plantillas es responsable de compilar plantillas de Vue en funciones de renderizado de Javascript puro. Si desea usar la opción `template`, entonces necesita el compilador.
 
-The template compiler is responsible for compiling Vue template strings into pure JavaScript render functions. If you want to use the `template` option, then you need the compiler.
+- La versión independiente incluye el compilador y soporta la opción `template`. **También depende de la presencia de APIs del navegador, por lo que no puede usarlo para renderizado del lado servidor.**
 
-- The standalone build includes the compiler and supports the `template` option. **It also relies on the presence of browser APIs so you cannot use it for server-side rendering.**
+- La versión _runtime-only_ no incluye el compilador de plantillas y no soporta la opción `template`. solo puede usar la opción `render` cuando se está usando esta versión, pero funciona con componentes de un solo archivo, porque las plantillas de los componentes de un solo archivo son pre-compiladas en funciones `render` durante la etapa de construcción. La versión _runtime-only_ es aproximadamente 30% más liviana que la versión independiente, ocupando solo {{ro_gz_size}}kb min+gzip.
 
-- The runtime-only build does not include the template compiler, and does not support the `template` option. You can only use the `render` option when using the runtime-only build, but it works with single-file components, because single-file components' templates are pre-compiled into `render` functions during the build step. The runtime-only build is roughly 30% lighter-weight than the standalone build, weighing only {{ro_gz_size}}kb min+gzip.
-
-By default, the NPM package exports the **runtime-only** build. To use the standalone build, add the following alias to your Webpack config:
+Por defecto, el paquete NPM exporta la versión **runtime-only**. Para usar la versión independiente, añada el siguiente alias en su archivo de configuración de Webpack:
 
 ``` js
 resolve: {
@@ -64,7 +63,7 @@ resolve: {
 }
 ```
 
-For Browserify, you can add an alias to your package.json:
+Para Browserify, puede añadir un alias a su archivo package.json:
 
 ``` js
 "browser": {
@@ -72,34 +71,34 @@ For Browserify, you can add an alias to your package.json:
 },
 ```
 
-<p class="tip">Do NOT do `import Vue from 'vue/dist/vue.js'` - since some tools or 3rd party libraries may import vue as well, this may cause the app to load both the runtime and standalone builds at the same time and lead to errors.</p>
+<p class="tip">No realice un `import Vue from 'vue/dist/vue.js'` - dado que algunas herramientas en bibliotecas de terceros pueden también importar vue y podría causar que la aplicación intente cargar ambas versiones al mismo tiempo, conduciendo a errores.</p>
 
-### CSP environments
+### Ambientes CSP
 
-Some environments, such as Google Chrome Apps, enforce Content Security Policy (CSP), which prohibits the use of `new Function()` for evaluating expressions. The standalone build depends on this feature to compile templates, so is unusable in these environments.
+Algunos ambientes, como las aplicaciones de Google Chrome, imponen las Políticas de Seguridad de Contenido (CSP por sus siglas en inglés), las cuales prohiben el uso de `new Function()` para la evaluación de expresiones. La versión independiente depende de esta característica para compilar plantillas, por lo que no es posible utilizarla en estos ambientes.
 
-On the other hand, the runtime-only build is fully CSP-compliant. When using the runtime-only build with [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple) or [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple), your templates will be precompiled into `render` functions which work perfectly in CSP environments.
+Por otro lado, la versión _runtime-only_ es completamente compatible con CSP. Cuando utilice la versión _runtime-only_ [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple) o [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple), sus plantillas serán pre-compiladas en funciones `render` las cuales funcionan perfectamente en ambientes CSP.
 
 ## CLI
 
-Vue.js provides an [official CLI](https://github.com/vuejs/vue-cli) for quickly scaffolding ambitious Single Page Applications. It provides batteries-included build setups for a modern frontend workflow. It takes only a few minutes to get up and running with hot-reload, lint-on-save, and production-ready builds:
+Vue.js provee una [CLI oficial](https://github.com/vuejs/vue-cli) para estructurar rápidamente aplicaciones ambiciosas de una sola página. Provee configuraciones _todo-en-uno_ para un flujo de trabajo frontend moderno. Solo toma unos minutos estar preparado para el desarrollo con: recarga en caliente, _lint-on-save_ y versiones listas para producción:
 
 ``` bash
-# install vue-cli
+# Instale vue-cli
 $ npm install --global vue-cli
-# create a new project using the "webpack" template
+# Cree un nuevo proyecto usando la plantilla "webpack"
 $ vue init webpack my-project
-# install dependencies and go!
+# Instale las dependencias y ¡listo!
 $ cd my-project
 $ npm install
 $ npm run dev
 ```
 
-<p class="tip">The CLI assumes prior knowledge of Node.js and the associated build tools. If you are new to Vue or front-end build tools, we strongly suggest going through <a href="./">the guide</a> without any build tools before using the CLI.</p>
+<p class="tip">La _CLI_ asume un conocimiento previo de Node.js y las herramientas de trabajo asociadas. Si usted es principiante con Vue o las herramientas de desarrollo front-end, le recomendamos fervientemente leer <a href="./">la guía</a> sin ninguna herramienta de desarrollo previo a usar la _CLI_.</p>
 
-## Dev Build
+## Versión desarrollo
 
-**Important**: the built files in GitHub's `/dist` folder are only checked-in during releases. To use Vue from the latest source code on GitHub, you will have to build it yourself!
+**Importante**: los archivos construidos dentro de la carpeta `/dist` de GitHub son compiladas solo durante lanzamientos. Para usar el código fuente más reciente de Vue en GitHub, ¡tendrá que construirlo usted mismo!
 
 ``` bash
 git clone https://github.com/vuejs/vue.git node_modules/vue
@@ -111,10 +110,10 @@ npm run build
 ## Bower
 
 ``` bash
-# latest stable
+# Última versión estable
 $ bower install vue
 ```
 
-## AMD Module Loaders
+## Gestores de módulos AMD
 
-The standalone downloads or versions installed via Bower are wrapped with UMD so they can be used directly as an AMD module.
+La versión independiente o las instaladas a través de Bower están encapsuladas con UMD, por lo que pueden ser usadas directamente como módulos AMD.


### PR DESCRIPTION
Una parte grande de las decisiones que tomé al traducir están discutidas en [este issue](https://github.com/vuejs-es/vuejs.org/issues/1). Decidí traducir _build (sustantivo)_ como _versión_ y dejar sin traducir _runtime-only_, _frontend_ y _lint-on-save_